### PR TITLE
Fixed compatibility with Python 3.12+

### DIFF
--- a/waf_tools/autoinstall_lib.py
+++ b/waf_tools/autoinstall_lib.py
@@ -276,14 +276,14 @@ def installsmthg_post(ctx,where,what,extra_config=""):
 
 def check_python_module(ctx,name,extracmd=""):
   import sys
-  import imp
+  import importlib
   import site
   site.addsitedir(ctx.env.PYTHONDIR)
   if ctx.env.PYTHONDIR not in sys.path:
     sys.path=[ctx.env.PYTHONDIR]+sys.path
   try:
     ctx.start_msg("Checking python module '%s'"%name)
-    imp.find_module(name)
+    importlib.util.find_spec(name)
     if extracmd:
       #print extracmd
       exec(extracmd)

--- a/wscript
+++ b/wscript
@@ -773,8 +773,8 @@ def configure_numpy(ctx):
   import autoinstall_lib as atl
   url,tar = atl.get_lib_url(ctx,"numpy",["http://sourceforge.net/projects/numpy/files/NumPy/1.6.0/numpy-1.6.0.tar.gz/download","numpy-1.6.0.tar.gz"])
   atl.configure_python_module(ctx,"numpy",url,tar,"numpy")
-  import imp
-  numpy = imp.load_module("numpy",*imp.find_module("numpy"))
+  import importlib
+  numpy = importlib.import_module("numpy")
   ctx.env.append_value("INCLUDES_PYEXT",numpy.get_include())
 
 def configure_pyfits(ctx):


### PR DESCRIPTION
The imp module has been removed since Python 3.12.
https://docs.python.org/3.12/whatsnew/3.12.html#imp